### PR TITLE
Issue #60/add ruff as main linter and code formatter

### DIFF
--- a/rdock-utils/.devcontainer/devcontainer.json
+++ b/rdock-utils/.devcontainer/devcontainer.json
@@ -9,29 +9,17 @@
 		"vscode": {
 			"settings": {
 				"python.languageServer": "Pylance",
-				"python.linting.enabled": true,
-				"python.linting.flake8Enabled": true,
-				"python.formatting.provider": "black",
-				"python.linting.mypyEnabled": false,
-				"isort.check": true,
 				"python.testing.pytestEnabled": true,
 				"python.testing.pytestArgs": [
 					"tests"
 				],
-				"python.formatting.blackArgs": [
-					"--line-length",
-					"119"
-				],
-				"isort.args": [
-					"--profile",
-					"black"
-				],
 				"[python]": {
+					"editor.formatOnSave": true,
 					"editor.codeActionsOnSave": {
 						"source.organizeImports": true
-					}
+					},
+					"editor.defaultFormatter": "charliermarsh.ruff"
 				},
-				"editor.formatOnSave": true,
 				"files.autoSave": "afterDelay",
 				"files.autoSaveDelay": 1000
 			},
@@ -40,7 +28,8 @@
 				"littlefoxteam.vscode-python-test-adapter",
 				"ms-vsliveshare.vsliveshare",
 				"mhutchie.git-graph",
-				"ms-toolsai.jupyter"
+				"ms-toolsai.jupyter",
+				"charliermarsh.ruff"
 			]
 		}
 	}

--- a/rdock-utils/pyproject.toml
+++ b/rdock-utils/pyproject.toml
@@ -1,13 +1,12 @@
-[tool.black]
+[tool.ruff]
 line-length = 119
-target-version = ['py312']
+target-version = "py312"
 
-[tool.isort]
-profile = "black"
-line_length = 119
-combine_as_imports = true
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 
-import_heading_stdlib = "Standard Library"
-import_heading_thirdparty = "Dependencies"
-import_heading_firstparty = "From apps"
-import_heading_localfolder = "Local imports"
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"


### PR DESCRIPTION
This is meant to add ruff as the main linter and code formatter. This would be a great contribution to the repository considering that just one dependency will handle the linting and formatting and ruff's current performance benchmarks. For more info: https://github.com/astral-sh/ruff 